### PR TITLE
Bump containerd.io version

### DIFF
--- a/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
+++ b/configs/linux/Agent/Ubuntu/Ubuntu.Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y  docker-ce=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
                         docker-ce-cli=${dockerLinuxComponentVersion}-$(lsb_release -cs) \
-                        containerd.io=1.2.13-2 \
+                        containerd.io:amd64=1.4.4-1 \
                         systemd && \
     systemctl disable docker && \
     sed -i -e 's/\r$//' /services/run-docker.sh && \


### PR DESCRIPTION
Upgrade containerd from1.2.13-2 -> 1.4.4-1 to a more recent version due to increasing insues with 1.2.13
- Release notes https://github.com/containerd/containerd/releases/tag/v1.4.4